### PR TITLE
Defined associated function to builds new cryptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cryptor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cryptor"
-version     = "0.1.2"
+version     = "0.1.3"
 authors     = ["atsushi130 <atsushi_main@outlook.jp>"]
 license     = "MIT/Apache-2.0"
 description = "Cryptor is encryption machine corresponding to the diversity of algorithms."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cryptor
-[![MIT / Apache2.0 dual licensed](https://img.shields.io/badge/dual%20license-MIT%20/%20Apache%202.0-blue.svg)](./LICENSE.md)
+[![MIT / Apache2.0 dual licensed](https://img.shields.io/badge/dual%20license-MIT%20/%20Apache%202.0-blue.svg)](./LICENSE-MIT.md)
 [![Travis Build Status](https://api.travis-ci.org/atsushi130/Cryptor.svg?branch=master)](https://travis-ci.org/atsushi130/Cryptor)
 [![crates.io](https://img.shields.io/crates/v/cryptor.svg)](https://crates.io/crates/cryptor)
-[![Document](https://img.shields.io/badge/Cryptor-Document-3B5998.svg)](https://docs.rs/cryptor/0.1.2/cryptor/)
+[![Document](https://img.shields.io/badge/Cryptor-Document-3B5998.svg)](https://docs.rs/cryptor/0.1.3/cryptor/)
 
 Cryptor is encryption machine corresponding to the diversity of algorithms.
 
@@ -10,7 +10,7 @@ Cryptor is encryption machine corresponding to the diversity of algorithms.
 Insert to Cargo.toml of your project.
 ```toml
 [dependencies]
-cryptor = "0.1.2"
+cryptor = "0.1.3"
 ```
 or
 ```console
@@ -18,7 +18,7 @@ or
 ❯ cargo add cryptor
 
 // Version specification
-❯ cargo add cryptor@0.1.2
+❯ cargo add cryptor@0.1.3
 
 // If not exist on crates.io
 ❯ mkdir lib
@@ -51,9 +51,7 @@ pub trait Algorithm {
 
 Cryptor have member with Algorithm trait. Dependency injection your implemented structure to Cryptor.
 ```rust
-let mut cryptor = Cryptor {
-    algorithm: YourAlgorithm { ... }
-};
+let mut cryptor = Cryptor::new(YourAlgorithm);
 ```
 
 Return type of encrypt and decrypt method is `CryptoValue<YourAlgorithm>`.
@@ -63,13 +61,6 @@ println!("encrypted string is {}", encrypted.text);
 
 let decrypted: CryptoValue<YourAlgorithm> = cryptor.decrypt(&string);
 println!("decrypted string is {}", decrypted.text);
-```
-
-Encrypter have member with Algorithm trait. Dependency injection your implemented structure to Encrypter.
-```rust
-let mut encrypter = Encrypter {
-    hash: YourAlgorithm { ... }
-};
 ```
 
 Return type of encrypt method is `EncryptValue<YourAlgorithm>`.
@@ -89,6 +80,24 @@ println!("encrypted character is {}", encrypted.text);
 ```console
 ❯ cargo test
 
+```
+
+## Change logs
+**v0.1.3**  
+Defined associated function to builds new Cryptor.
+```rust
+impl<T: Algorithm> Cryptor<T> {
+    pub fn new(algorithm: T) -> Self {
+        Cryptor {
+            algorithm
+        }
+    }
+}
+```
+
+**changed usage**
+```rust
+let mut cryptor = Cryptor::new(your_algorithm);
 ```
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ let decrypted: CryptoValue<YourAlgorithm> = cryptor.decrypt(&string);
 println!("decrypted string is {}", decrypted.text);
 ```
 
-Return type of encrypt method is `EncryptValue<YourAlgorithm>`.
-```rust
-let encrypted: EncryptValue<YourAlgorithm> = encrypter.encrypt(&character);
-println!("encrypted character is {}", encrypted.text);
-```
-
 ## Run
 ```console
 ❯ cargo build

--- a/src/cryptor/algorithm/base64/README.md
+++ b/src/cryptor/algorithm/base64/README.md
@@ -1,6 +1,6 @@
 # Base64
 [![Base64](https://img.shields.io/badge/Cryptor-Base64-6fb536.svg)](https://github.com/atsushi130/Cryptor/tree/master/src/cryptor/algorithm/base64)
-[![Document](https://img.shields.io/badge/Base64-Document-3B5998.svg)](https://docs.rs/cryptor/0.1.2/cryptor/cryptor/struct.Base64.html)
+[![Document](https://img.shields.io/badge/Base64-Document-3B5998.svg)](https://docs.rs/cryptor/0.1.3/cryptor/cryptor/struct.Base64.html)
 
 ## Usage
 **Import modules**
@@ -12,7 +12,7 @@ use cryptor::cryptor::{ Cryptor, CryptoValue };
 
 **Setup Cryptor**  
 ```rust
-let mut cryptor = Cryptor { algorithm: Base64 };
+let mut cryptor = Cryptor::new(Base64);
 ```
 
 **Encryption**  

--- a/src/cryptor/algorithm/enigma/README.md
+++ b/src/cryptor/algorithm/enigma/README.md
@@ -1,6 +1,6 @@
 # Enigma
 [![Enigma](https://img.shields.io/badge/Cryptor-Enigma-6fb536.svg)](https://github.com/atsushi130/Cryptor/tree/master/src/cryptor/algorithm/enigma)
-[![Document](https://img.shields.io/badge/Enigma-Document-3B5998.svg)](https://docs.rs/cryptor/0.1.2/cryptor/cryptor/struct.Enigma.html)
+[![Document](https://img.shields.io/badge/Enigma-Document-3B5998.svg)](https://docs.rs/cryptor/0.1.3/cryptor/cryptor/struct.Enigma.html)
 
 ## Usage
 **Import modules**
@@ -27,7 +27,7 @@ let enigma = Enigma::new(
 
 **Setup Cryptor**  
 ```rust
-let mut cryptor = Cryptor { algorithm: enigma };
+let mut cryptor = Cryptor::new(enigma);
 ```
 
 **Encryption**  

--- a/src/cryptor/algorithm/enigma/enigma.rs
+++ b/src/cryptor/algorithm/enigma/enigma.rs
@@ -83,8 +83,6 @@ impl Enigma {
     }
 
     fn build_base64_cryptor(&self) -> Cryptor<Base64> {
-        Cryptor {
-            algorithm: Base64
-        }
+        Cryptor::new(Base64)
     }
 }

--- a/src/cryptor/cryptor.rs
+++ b/src/cryptor/cryptor.rs
@@ -14,6 +14,12 @@ pub struct Cryptor<T: Algorithm> {
 
 impl<T: Algorithm> Cryptor<T> {
 
+    pub fn new(algorithm: T) -> Self {
+        Cryptor {
+            algorithm
+        }
+    }
+
     pub fn encrypt(&mut self, string: &str) -> CryptoValue<T::V> {
         self.algorithm.encrypt(string)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ mod utility;
 
 #[cfg(not(test))]
 fn main() {
-    let mut cryptor = Cryptor {
-        algorithm: Enigma::new(
+
+    let enigma = Enigma::new(
             vec![
                 Router::new(SubstitutionTable::new(SUBSTITUTION_TABLE1.to_vec())),
                 Router::new(SubstitutionTable::new(SUBSTITUTION_TABLE2.to_vec())),
@@ -34,8 +34,9 @@ fn main() {
             ],
             Plugboard::new(SubstitutionTable::new(PLUGBOARD.to_vec())),
             Reflector::new(SubstitutionTable::new(REFLECTOR.to_vec()))
-        )
-    };
+        );
+
+    let mut cryptor = Cryptor::new(enigma);
 
     let characters1 = "0V+/;e.\"%¥HN=P\"%WLkKC=xK[N<(DemmE=+.D\"bErC#X!|^G.{#5:KVr";
     let characters2 = "**~_}*jl\'*fK\'=eG\'\'sP\'\\n<MMY@";

--- a/tests/cryptor_tests/cryptor.rs
+++ b/tests/cryptor_tests/cryptor.rs
@@ -17,9 +17,7 @@ mod encrypter_tests {
     #[test]
     fn encryptable() {
 
-        #[allow(unused_mut)]
-        let mut encrypter = Cryptor {
-            algorithm: Enigma::new(
+        let enigma = Enigma::new(
                 vec![
                     Router::new(SubstitutionTable::new(ALPHABETS.to_vec())),
                     Router::new(SubstitutionTable::new(ALPHABETS.to_vec())),
@@ -27,19 +25,19 @@ mod encrypter_tests {
                 ],
                 Plugboard::new(SubstitutionTable::new(ALPHABETS.to_vec())),
                 Reflector::new(SubstitutionTable::new(ALPHABETS.to_vec()))
-            )
-        };
+            );
 
-        let result: CryptoValue<Enigma> = encrypter.encrypt(&'A');
-        assert_eq!("A", result.text);
+        #[allow(unused_mut)]
+        let mut encrypter = Cryptor::new(enigma);
+
+        let result: CryptoValue<Enigma> = encrypter.encrypt(&"A");
+        assert_eq!("QQ==", result.text);
     }
 
     #[test]
     fn encryptable_two_characters() {
 
-        #[allow(unused_mut)]
-        let mut encrypter = Cryptor {
-            algorithm: Enigma::new(
+        let enigma = Enigma::new(
                 vec![
                     Router::new(SubstitutionTable::new(ALPHABETS.to_vec())),
                     Router::new(SubstitutionTable::new(ALPHABETS.to_vec())),
@@ -47,13 +45,15 @@ mod encrypter_tests {
                 ],
                 Plugboard::new(SubstitutionTable::new(ALPHABETS.to_vec())),
                 Reflector::new(SubstitutionTable::new(ALPHABETS.to_vec()))
-            )
-        };
+            );
 
-        let result1: CryptoValue<Enigma> = encrypter.encrypt(&'A');
-        let result2: CryptoValue<Enigma> = encrypter.encrypt(&'A');
+        #[allow(unused_mut)]
+        let mut encrypter = Cryptor::new(enigma);
 
-        assert_eq!("A", result1.text);
-        assert_eq!("A", result2.text);
+        let result1: CryptoValue<Enigma> = encrypter.encrypt(&"A");
+        let result2: CryptoValue<Enigma> = encrypter.encrypt(&"A");
+
+        assert_eq!("QQ==", result1.text);
+        assert_eq!("QQ==", result2.text);
     }
 }

--- a/tests/cryptor_tests/mod.rs
+++ b/tests/cryptor_tests/mod.rs
@@ -6,3 +6,4 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 pub mod algorithm;
+pub mod cryptor;


### PR DESCRIPTION
## Issue
#6 #9 

## Done
- [x] defined associated function to builds new Cryptor
- [x] fixed the source used Cryptor
- [x] update version
- [x] update documentation

## Changed usage
**before**
```rust
let mut cryptor = Cryptor { algorithm: YourAlgorithm };
```

**after**
```rust
let mut cryptor = Cryptor::new(YourAlgorithm);
```
